### PR TITLE
Add support for converting a GPTQ model to 2:4 structured sparse marlin format for 4-bit and 8-bit

### DIFF
--- a/auto_gptq/modeling/_base.py
+++ b/auto_gptq/modeling/_base.py
@@ -713,6 +713,7 @@ os.environ['NUMEXPR_MAX_THREADS'] = max_threads
         use_triton: bool = False,
         use_qigen: bool = False,
         use_marlin: bool = False,
+        use_marlin_24: bool = False,
         torch_dtype: Optional[torch.dtype] = None,
         inject_fused_attention: bool = False,
         inject_fused_mlp: bool = False,
@@ -829,6 +830,9 @@ os.environ['NUMEXPR_MAX_THREADS'] = max_threads
             if not isinstance(quantize_config, BaseQuantizeConfig):
                 quantize_config = BaseQuantizeConfig.from_quant_config(quantize_config, checkpoint_format)
 
+        if use_marlin_24:
+            use_marlin = True
+        
         if quantize_config.checkpoint_format == CHECKPOINT_FORMAT.MARLIN:
             # format marlin requires marlin kernel
             use_marlin = True
@@ -1121,6 +1125,7 @@ os.environ['NUMEXPR_MAX_THREADS'] = max_threads
                     torch_dtype=torch_dtype,
                     current_model_save_name=model_save_name,
                     device_map=device_map,
+                    is_24=use_marlin_24
                 )
 
                 # Disable incompatible optimizations.

--- a/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
@@ -17,7 +17,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-
 logger = getLogger(__name__)
 
 try:
@@ -45,7 +44,8 @@ def mul(A, B, C, s, workspace, thread_k=-1, thread_n=-1, sms=-1, max_par=16):
     @sms: number of SMs to use for the kernel (can usually be left as auto -1)
     @max_par: maximum number of batch 64 problems to solve in parallel for large input sizes
     """
-    autogptq_marlin_cuda.mul(A, B, C, s, workspace, thread_k, thread_n, sms, max_par)
+    autogptq_marlin_cuda.mul(A, B, C, s, workspace, thread_k, thread_n, sms,
+                             max_par)
 
 
 # Precompute permutations for Marlin weight and scale shuffling
@@ -58,10 +58,10 @@ def _get_perms():
         col = i // 4
         for block in [0, 1]:
             for row in [
-                2 * (i % 4),
-                2 * (i % 4) + 1,
-                2 * (i % 4 + 4),
-                2 * (i % 4 + 4) + 1,
+                    2 * (i % 4),
+                    2 * (i % 4) + 1,
+                    2 * (i % 4 + 4),
+                    2 * (i % 4 + 4) + 1,
             ]:
                 perm1.append(16 * row + col + 8 * block)
         for j in range(4):
@@ -76,7 +76,8 @@ def _get_perms():
         scale_perm.extend([i + 8 * j for j in range(8)])
     scale_perm_single = []
     for i in range(4):
-        scale_perm_single.extend([2 * i + j for j in [0, 1, 8, 9, 16, 17, 24, 25]])
+        scale_perm_single.extend(
+            [2 * i + j for j in [0, 1, 8, 9, 16, 17, 24, 25]])
     return perm, scale_perm, scale_perm_single
 
 
@@ -86,7 +87,15 @@ _perm, _scale_perm, _scale_perm_single = _get_perms()
 class QuantLinear(nn.Module):
     QUANT_TYPE = "marlin"
 
-    def __init__(self, bits, group_size, infeatures, outfeatures, bias, is_24, trainable=False, **kwargs):
+    def __init__(self,
+                 bits,
+                 group_size,
+                 infeatures,
+                 outfeatures,
+                 bias,
+                 is_24,
+                 trainable=False,
+                 **kwargs):
         super().__init__()
 
         if torch.version.hip:
@@ -99,9 +108,11 @@ class QuantLinear(nn.Module):
             )
 
         if infeatures % 128 != 0 or outfeatures % 256 != 0:
-            raise ValueError("`infeatures` must be divisible by 128 and `outfeatures` by 256.")
-        if bits not in [4]:
-            raise NotImplementedError("Only 4 bits are supported.")
+            raise ValueError(
+                "`infeatures` must be divisible by 128 and `outfeatures` by 256."
+            )
+        if bits not in [4, 8]:
+            raise NotImplementedError("Only 4 or 8 bits are supported.")
         if group_size not in [-1, 128] and group_size != infeatures:
             raise ValueError("Only group_size -1 and 128 are supported.")
         if infeatures % group_size != 0:
@@ -111,15 +122,22 @@ class QuantLinear(nn.Module):
 
         self.infeatures = infeatures
         self.outfeatures = outfeatures
+
+        self.num_bits = bits
+        self.pack_factor = 32 // self.num_bits
         self.group_size = group_size if group_size != -1 else infeatures
+
         if is_24:
             self.register_buffer(
                 "B_24",
-                torch.empty((self.infeatures // 16 // 2, self.outfeatures * 16 // 8), dtype=torch.int),
+                torch.empty((self.infeatures // 16 // 2,
+                             self.outfeatures * 16 // self.pack_factor),
+                            dtype=torch.int),
             )
             self.register_buffer(
                 "B_meta",
-                torch.empty((self.outfeatures, self.infeatures // 2 // 8), dtype=torch.int16),
+                torch.empty((self.outfeatures, self.infeatures // 2 // 8),
+                            dtype=torch.int16),
             )
             # self.register_buffer(
             #     "B_ref",
@@ -129,11 +147,14 @@ class QuantLinear(nn.Module):
         else:
             self.register_buffer(
                 "B",
-                torch.empty((self.infeatures // 16, self.outfeatures * 16 // 8), dtype=torch.int),
+                torch.empty((self.infeatures // 16,
+                             self.outfeatures * 16 // self.pack_factor),
+                            dtype=torch.int),
             )
         self.register_buffer(
             "s",
-            torch.empty((self.infeatures // group_size, self.outfeatures), dtype=torch.half),
+            torch.empty((self.infeatures // group_size, self.outfeatures),
+                        dtype=torch.half),
         )
         # 128 is currently the minimum `tile_n`, hence it gives the maximum workspace size; 16 is the default `max_par`
         self.register_buffer(
@@ -142,7 +163,8 @@ class QuantLinear(nn.Module):
             persistent=False,
         )
         if bias:
-            self.register_buffer("bias", torch.zeros((outfeatures), dtype=torch.half))
+            self.register_buffer("bias",
+                                 torch.zeros((outfeatures), dtype=torch.half))
         else:
             self.bias = None
 
@@ -157,7 +179,7 @@ class QuantLinear(nn.Module):
         if linear.weight.dtype != torch.half:
             raise ValueError("Only `torch.half` weights are supported.")
         tile = 16
-        maxq = 2**4 - 1
+        maxq = (1 << self.num_bits) - 1
         s = scales.t()
         w = linear.weight.data.t()
         if self.group_size != self.infeatures:
@@ -176,15 +198,16 @@ class QuantLinear(nn.Module):
         else:
             s = s.reshape((-1, len(_scale_perm_single)))[:, _scale_perm_single]
         s = s.reshape((-1, self.outfeatures)).contiguous()
-        w = w.reshape((self.infeatures // tile, tile, self.outfeatures // tile, tile))
+        w = w.reshape(
+            (self.infeatures // tile, tile, self.outfeatures // tile, tile))
         w = w.permute((0, 2, 1, 3))
         w = w.reshape((self.infeatures // tile, self.outfeatures * tile))
         res = w
         res = res.reshape((-1, _perm.numel()))[:, _perm].reshape(res.shape)
-        q = np.zeros((res.shape[0], res.shape[1] // 8), dtype=np.uint32)
+        q = np.zeros((res.shape[0], res.shape[1] // self.pack_factor), dtype=np.uint32)
         res = res.cpu().numpy().astype(np.uint32)
-        for i in range(8):
-            q |= res[:, i::8] << 4 * i
+        for i in range(self.pack_factor):
+            q |= res[:, i::self.pack_factor] << self.num_bits * i
         q = torch.from_numpy(q.astype(np.int32)).to(w.device)
         self.B[:, :] = q.to(self.B.device)
         self.s[:, :] = s.to(self.s.device)
@@ -196,7 +219,9 @@ class QuantLinear(nn.Module):
 
     def forward(self, A):
         A = A.half()
-        C = torch.empty(A.shape[:-1] + (self.s.shape[1],), dtype=A.dtype, device=A.device)
+        C = torch.empty(A.shape[:-1] + (self.s.shape[1], ),
+                        dtype=A.dtype,
+                        device=A.device)
         mul(
             A.view((-1, A.shape[-1])),
             self.B,
@@ -256,7 +281,8 @@ def unpack_qzeros(qzeros):
 @torch.no_grad()
 def dequantize_weight(layer):
     qweight, qzeros, scales = layer.qweight, layer.qzeros, layer.scales
-    unpacked_qweight, unpacked_qzeros = unpack_4bit_to_32bit_signed(qweight, qzeros)
+    unpacked_qweight, unpacked_qzeros = unpack_4bit_to_32bit_signed(
+        qweight, qzeros)
     group_size = unpacked_qweight.shape[0] // scales.shape[0]
     scales = scales.repeat_interleave(group_size, dim=0)
     unpacked_qzeros = unpacked_qzeros.repeat_interleave(group_size, dim=0)

--- a/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
+++ b/auto_gptq/nn_modules/qlinear/qlinear_marlin.py
@@ -45,7 +45,8 @@ def mul(A, B, C, s, workspace, thread_k=-1, thread_n=-1, sms=-1, max_par=16):
     @sms: number of SMs to use for the kernel (can usually be left as auto -1)
     @max_par: maximum number of batch 64 problems to solve in parallel for large input sizes
     """
-    autogptq_marlin_cuda.mul(A, B, C, s, workspace, thread_k, thread_n, sms, max_par)
+    autogptq_marlin_cuda.mul(A, B, C, s, workspace, thread_k, thread_n, sms,
+                             max_par)
 
 
 # Precompute permutations for Marlin weight and scale shuffling
@@ -58,10 +59,10 @@ def _get_perms():
         col = i // 4
         for block in [0, 1]:
             for row in [
-                2 * (i % 4),
-                2 * (i % 4) + 1,
-                2 * (i % 4 + 4),
-                2 * (i % 4 + 4) + 1,
+                    2 * (i % 4),
+                    2 * (i % 4) + 1,
+                    2 * (i % 4 + 4),
+                    2 * (i % 4 + 4) + 1,
             ]:
                 perm1.append(16 * row + col + 8 * block)
         for j in range(4):
@@ -76,7 +77,8 @@ def _get_perms():
         scale_perm.extend([i + 8 * j for j in range(8)])
     scale_perm_single = []
     for i in range(4):
-        scale_perm_single.extend([2 * i + j for j in [0, 1, 8, 9, 16, 17, 24, 25]])
+        scale_perm_single.extend(
+            [2 * i + j for j in [0, 1, 8, 9, 16, 17, 24, 25]])
     return perm, scale_perm, scale_perm_single
 
 
@@ -86,16 +88,30 @@ _perm, _scale_perm, _scale_perm_single = _get_perms()
 class QuantLinear(nn.Module):
     QUANT_TYPE = "marlin"
 
-    def __init__(self, bits, group_size, infeatures, outfeatures, bias, trainable=False, **kwargs):
+    def __init__(self,
+                 bits,
+                 group_size,
+                 infeatures,
+                 outfeatures,
+                 bias,
+                 is_24,
+                 trainable=False,
+                 **kwargs):
         super().__init__()
 
         if torch.version.hip:
-            raise ValueError("Can not use Marlin int4*fp16 kernel with AMD ROCm version of PyTorch as the kernel is not compatible. Please do not use `use_marlin=True` when using ROCm devices.")
+            raise ValueError(
+                "Can not use Marlin int4*fp16 kernel with AMD ROCm version of PyTorch as the kernel is not compatible. Please do not use `use_marlin=True` when using ROCm devices."
+            )
         if not torch.cuda.get_device_capability()[0] >= 8:
-            raise ValueError(f'Can not use Marlin int4*fp16 kernel with a device of compute capability {torch.cuda.get_device_capability()}, the minimum compute capability is 8.0 for Marlin kernel. Please do not use `use_marlin=True`, or please upgrade your GPU ("The more you buy, the more you save." - Taiwanese proverb).')
+            raise ValueError(
+                f'Can not use Marlin int4*fp16 kernel with a device of compute capability {torch.cuda.get_device_capability()}, the minimum compute capability is 8.0 for Marlin kernel. Please do not use `use_marlin=True`, or please upgrade your GPU ("The more you buy, the more you save." - Taiwanese proverb).'
+            )
 
         if infeatures % 128 != 0 or outfeatures % 256 != 0:
-            raise ValueError("`infeatures` must be divisible by 128 and `outfeatures` by 256.")
+            raise ValueError(
+                "`infeatures` must be divisible by 128 and `outfeatures` by 256."
+            )
         if bits not in [4]:
             raise NotImplementedError("Only 4 bits are supported.")
         if group_size not in [-1, 128] and group_size != infeatures:
@@ -108,13 +124,34 @@ class QuantLinear(nn.Module):
         self.infeatures = infeatures
         self.outfeatures = outfeatures
         self.group_size = group_size if group_size != -1 else infeatures
-        self.register_buffer(
-            "B",
-            torch.empty((self.infeatures // 16, self.outfeatures * 16 // 8), dtype=torch.int),
-        )
+        if is_24:
+            self.register_buffer(
+                "B_24",
+                torch.empty(
+                    (self.infeatures // 16 // 2, self.outfeatures * 16 // 8),
+                    dtype=torch.int),
+            )
+            self.register_buffer(
+                "B_meta",
+                torch.empty((self.outfeatures, self.infeatures // 2 // 8),
+                            dtype=torch.int16),
+            )
+            # self.register_buffer(
+            #     "B_ref",
+            #     torch.empty((self.infeatures, self.outfeatures),
+            #                 dtype=torch.half),
+            # )
+        else:
+            self.register_buffer(
+                "B",
+                torch.empty(
+                    (self.infeatures // 16, self.outfeatures * 16 // 8),
+                    dtype=torch.int),
+            )
         self.register_buffer(
             "s",
-            torch.empty((self.infeatures // group_size, self.outfeatures), dtype=torch.half),
+            torch.empty((self.infeatures // group_size, self.outfeatures),
+                        dtype=torch.half),
         )
         # 128 is currently the minimum `tile_n`, hence it gives the maximum workspace size; 16 is the default `max_par`
         self.register_buffer(
@@ -123,7 +160,8 @@ class QuantLinear(nn.Module):
             persistent=False,
         )
         if bias:
-            self.register_buffer("bias", torch.zeros((outfeatures), dtype=torch.half))
+            self.register_buffer("bias",
+                                 torch.zeros((outfeatures), dtype=torch.half))
         else:
             self.bias = None
 
@@ -157,7 +195,8 @@ class QuantLinear(nn.Module):
         else:
             s = s.reshape((-1, len(_scale_perm_single)))[:, _scale_perm_single]
         s = s.reshape((-1, self.outfeatures)).contiguous()
-        w = w.reshape((self.infeatures // tile, tile, self.outfeatures // tile, tile))
+        w = w.reshape(
+            (self.infeatures // tile, tile, self.outfeatures // tile, tile))
         w = w.permute((0, 2, 1, 3))
         w = w.reshape((self.infeatures // tile, self.outfeatures * tile))
         res = w
@@ -177,7 +216,9 @@ class QuantLinear(nn.Module):
 
     def forward(self, A):
         A = A.half()
-        C = torch.empty(A.shape[:-1] + (self.s.shape[1],), dtype=A.dtype, device=A.device)
+        C = torch.empty(A.shape[:-1] + (self.s.shape[1], ),
+                        dtype=A.dtype,
+                        device=A.device)
         mul(
             A.view((-1, A.shape[-1])),
             self.B,
@@ -217,6 +258,7 @@ def unpack_4bit_to_32bit_signed(qweight, qzeros):
 
     return unpacked_weights, unpacked_zeros + 1
 
+
 def unpack_qzeros(qzeros):
     unpacked_zeros = torch.zeros(
         (qzeros.shape[0], qzeros.shape[1] * 8),
@@ -236,13 +278,15 @@ def unpack_qzeros(qzeros):
 @torch.no_grad()
 def dequantize_weight(layer):
     qweight, qzeros, scales = layer.qweight, layer.qzeros, layer.scales
-    unpacked_qweight, unpacked_qzeros = unpack_4bit_to_32bit_signed(qweight, qzeros)
+    unpacked_qweight, unpacked_qzeros = unpack_4bit_to_32bit_signed(
+        qweight, qzeros)
     group_size = unpacked_qweight.shape[0] // scales.shape[0]
     scales = scales.repeat_interleave(group_size, dim=0)
     unpacked_qzeros = unpacked_qzeros.repeat_interleave(group_size, dim=0)
     unpacked_qweight = (unpacked_qweight - unpacked_qzeros) * scales
 
     return unpacked_qweight.T, unpacked_qzeros
+
 
 def dequantize_qzeros(layer):
     qzeros = layer.qzeros

--- a/auto_gptq/quantization/config.py
+++ b/auto_gptq/quantization/config.py
@@ -108,7 +108,9 @@ class BaseQuantizeConfig(PushToHubMixin):
             if checkpoint_format not in valid_formats:
                 raise ValueError(f"Unknown quantization checkpoint format: {checkpoint_format}.")
             if quantize_cfg.get(CHECKPOINT_FORMAT_FIELD):
-                raise ValueError("Conflict: quantization checkpoint_format is passed in and also exists in model config.")
+                raise ValueError(
+                    "Conflict: quantization checkpoint_format is passed in and also exists in model config."
+                )
         # compat: warn if checkpoint_format is missing
         elif quantize_cfg.get(CHECKPOINT_FORMAT_FIELD) is None:
             checkpoint_format_auto_inferred = True
@@ -161,10 +163,7 @@ class BaseQuantizeConfig(PushToHubMixin):
                 f"`checkpoint_format` is missing from the quantization configuration and is automatically inferred to {normalized[CHECKPOINT_FORMAT_FIELD]}."
             )
 
-        if normalized[CHECKPOINT_FORMAT_FIELD] in {
-            CHECKPOINT_FORMAT.AWQ_GEMM,
-            CHECKPOINT_FORMAT.MARLIN,
-        }:
+        if normalized[CHECKPOINT_FORMAT_FIELD] in {CHECKPOINT_FORMAT.AWQ_GEMM, CHECKPOINT_FORMAT.MARLIN}:
             # AWQ and Marlin do not reorder the rows.
             normalized["desc_act"] = False
 
@@ -192,7 +191,7 @@ class BaseQuantizeConfig(PushToHubMixin):
 
         transformers_config = False
         for quantize_config_filename in [
-            "config.json",
+            "config.json",  # TODO: Remove this change
             QUANT_CONFIG_FILENAME,
             "quant_config.json",
         ]:

--- a/auto_gptq/utils/_semi_structured_conversions.py
+++ b/auto_gptq/utils/_semi_structured_conversions.py
@@ -1,0 +1,314 @@
+#
+# Copyright (C) 2024 Roberto Lopez Castro (roberto.lopez.castro@udc.es). All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+
+
+# This is PyTorch implementation of main part of reorder_meta()
+# function, from tools/util/include/cutlass/util/host_reorder.h file
+# of CUTLASS source tree.  Furthermore, CUTLASS template for sparse
+# GEMM decides upon layout of this matrix, and at the moment for the
+# sparse GEMM executed on tensor cores, this is layout described by
+# ColumnMajorInterleaved<2> data structure, in
+# include/cutlass/layout/matrix.h of CUTLASS source tree.  The
+# reordering of meta matrix into meta_reordered matrix calculated
+# according to these segments of CUTLASS code is re-implemented here.
+# Note that this calculation produces offsets for scattering metadata
+# matrix elements into reordered metadata matrix elements (or,
+# equivalently, for gathering reordered metadata matrix element back
+# into metadata matrix elements).
+def _calculate_meta_reordering_scatter_offsets(m, meta_ncols, meta_dtype,
+                                               device):
+    dst_rows = torch.arange(0, m, device=device)[:, None].repeat(1, meta_ncols)
+    dst_cols = torch.arange(0, meta_ncols, device=device).repeat(m, 1)
+
+    # Reorder the rows, then swizzle the 2x2 blocks.
+    """ print(meta_dtype, meta_dtype.itemsize, m, meta_ncols)
+    print(dst_rows[:8], dst_rows.shape)
+    print(dst_cols[:8], dst_cols.shape) """
+    group_x = 64
+    group_y = 32 if meta_dtype.itemsize == 2 else 16
+    interweave = 4 if meta_dtype.itemsize == 2 else 2
+    """ dst_rows = (
+        dst_rows // group_y * group_y
+        + (dst_rows % 8) * interweave
+        + (dst_rows % group_y) // 8
+    ) """
+    """ dst_rows = (
+        dst_rows // group_x * group_x
+        + (dst_rows % 2)
+        + ((dst_rows % group_y) % 4) // 2 * 32
+        + ((dst_rows % group_y) // 4) * 2
+        + (dst_rows % group_x) // group_y * 16
+    ) """
+    """ dst_rows = (
+        dst_rows // group_x * group_x
+        + (dst_rows % 2) * 2
+        + ((dst_rows % group_y) % 4) // 2 * 32
+        + ((dst_rows % group_y) // 4) * 4
+        + (dst_rows % group_x) // group_y
+    ) """
+    dst_rows = (dst_rows // group_x * group_x + (dst_rows % 2) * 2 +
+                (dst_rows % 8) // 4 + ((dst_rows % group_y) % 4) // 2 * 32 +
+                ((dst_rows % group_x) // 8) * 4)
+    #print(dst_rows[:65], dst_rows.shape)
+
+    topright = ((dst_rows % 2 == 0) & (dst_cols % 2 == 1)).to(torch.int8)
+    bottomleft = ((dst_rows % 2 == 1) & (dst_cols % 2 == 0)).to(torch.int8)
+    dst_rows += topright - bottomleft
+    dst_cols -= topright - bottomleft
+
+    # Assumed that meta tensor is to be stored in CUTLASS
+    # InterleavedColumnMajor layout, and reverse engineered
+    # corresponding code to store values into this tensor.
+    interleave = 2
+    cols_maj = dst_cols // interleave
+    cols_min = dst_cols % interleave
+    return (cols_maj * m * interleave + dst_rows * interleave +
+            cols_min).view(-1)
+
+
+# This function converts dense matrix into sparse semi-structured
+# representation, producing "compressed" matrix, in the layout used by
+# CUTLASS backend, and corresponding metadata matrix.
+def sparse_semi_structured_from_dense_cutlass(dense):
+    if dense.dim() != 2:
+        raise RuntimeError(
+            f"Expected 2-dimensional dense tensor, got {dense.dim()}-dimensional tensor"
+        )
+
+    m, k = dense.shape
+    device = dense.device
+
+    meta_dtype = torch.int8
+    if dense.dtype == torch.int8:
+        meta_dtype = torch.int32
+    elif dense.dtype in [torch.half, torch.bfloat16, torch.float]:
+        meta_dtype = torch.int16
+    else:
+        raise RuntimeError(f"Invalid datatype {dense.dtype} of dense matrix")
+    quadbits_per_meta_elem = meta_dtype.itemsize * 8 // 4
+    if quadbits_per_meta_elem not in (4, 8):
+        raise RuntimeError(
+            "Invalid number of elements per meta element calculated")
+
+    if meta_dtype == torch.int32:
+        if m % 16 != 0:
+            raise RuntimeError(
+                f"Number of rows of dense matrix {m} must be divisible by 16")
+    else:
+        if m % 32 != 0:
+            raise RuntimeError(
+                f"Number of rows of dense matrix {m} must be divisible by 32")
+    if k % (4 * quadbits_per_meta_elem) != 0:
+        raise RuntimeError(
+            f"Number of columns of dense matrix {k} must be divisible by {4 * quadbits_per_meta_elem}"
+        )
+
+    if dense.dtype != torch.float:
+        ksparse = 4
+        dense_4 = dense.view(-1, k // ksparse, ksparse)
+        m0, m1, m2, m3 = (dense_4 != 0).unbind(-1)
+    else:
+        ksparse = 2
+        dense_2 = dense.view(-1, k // ksparse, ksparse)
+        m0, m2 = m1, m3 = (dense_2 != 0).unbind(-1)
+    meta_ncols = k // (ksparse * quadbits_per_meta_elem)
+
+    # Encoding quadruples of True/False values as follows:
+    #     [True,  True,  False, False] -> 0b0100
+    #     [True,  False, True,  False] -> 0b1000
+    #     [False, True,  True,  False] -> 0b1001
+    #     [True,  False, False, True ] -> 0b1100
+    #     [False, True,  False, True ] -> 0b1101
+    #     [False, False, True,  True ] -> 0b1110
+    # Thus, lower two bits in the encoding are index of the True value
+    # at the lowest index in the quadruple, and the higher two bits in
+    # the encoding are index of the other True value in the quadruple.
+    # In case there are less than two True values, than False value or
+    # values at some index or indices are considered True for the
+    # encoding.  In case there are more than two True values, then the
+    # excess True value(s) at some indices are considered False for
+    # the encoding.  The exact encodings used for these cases are as
+    # follows:
+    #     [False, False, False, False] -> 0b1110
+    #     [False, False, False, True ] -> 0b1110
+    #     [False, False, True,  False] -> 0b1110
+    #     [False, True,  False, False] -> 0b1001
+    #     [False, True,  True,  True ] -> 0b1101
+    #     [True,  False, False, False] -> 0b1000
+    #     [True,  False, True,  True ] -> 0b1100
+    #     [True,  True,  False, True ] -> 0b0100
+    #     [True,  True,  True,  False] -> 0b0100
+    #     [True,  True,  True,  True ] -> 0b0100
+    # These particular encodings are chosen, with the help of Espresso
+    # logic minimizer software, for the purpose of minimization of
+    # corresponding Boolean functions, that translate non-zero flags
+    # into encoding bits.  Note also possible choices for the first
+    # and last of these encodings were limited only to (0b0100,
+    # 0b1110), in order to produce valid encodings for 1:2 sparsity
+    # case.
+
+    expr0 = m0 & m1
+    expr1 = ~m0 & m1
+    expr2 = ~m0 & ~m1
+    bit0 = expr1
+    bit1 = expr2
+    bit2 = expr0 | expr2 | m3
+    bit3 = expr1 | ~m1
+    idxs0 = bit0 | (bit1.to(torch.int64) << 1)
+    idxs1 = bit2 | (bit3.to(torch.int64) << 1)
+
+    if dense.dtype != torch.float:
+        sparse0 = dense_4.gather(
+            -1, idxs0.unsqueeze(-1))  # type: ignore[possibly-undefined]
+        sparse1 = dense_4.gather(-1, idxs1.unsqueeze(-1))
+        sparse = torch.stack((sparse0, sparse1), dim=-1).view(m, k // 2)
+    else:
+        sparse = dense_2.gather(-1,
+                                idxs0.unsqueeze(-1) // 2).view(
+                                    m,
+                                    k // 2)  # type: ignore[possibly-undefined]
+
+    meta_4 = idxs0 | (idxs1 << 2)
+    meta_n = meta_4.view(
+        (-1, meta_ncols, quadbits_per_meta_elem)).to(meta_dtype)
+
+    if quadbits_per_meta_elem == 4:
+        meta = (meta_n[:, :, 0]
+                | (meta_n[:, :, 1] << 4)
+                | (meta_n[:, :, 2] << 8)
+                | (meta_n[:, :, 3] << 12))
+    elif quadbits_per_meta_elem == 8:
+        meta = (meta_n[:, :, 0]
+                | (meta_n[:, :, 1] << 4)
+                | (meta_n[:, :, 2] << 8)
+                | (meta_n[:, :, 3] << 12)
+                | (meta_n[:, :, 4] << 16)
+                | (meta_n[:, :, 5] << 20)
+                | (meta_n[:, :, 6] << 24)
+                | (meta_n[:, :, 7] << 28))
+
+    # Reorder meta tensor elements.
+    meta_reordered = meta.new_empty(
+        (m * meta_ncols, ))  # type: ignore[possibly-undefined]
+    meta_offsets = _calculate_meta_reordering_scatter_offsets(
+        m, meta_ncols, meta_dtype, device)
+    meta_reordered.scatter_(0, meta_offsets, meta.view(-1))
+
+    return (sparse, meta_reordered.view(m, meta_ncols))
+
+
+# This function performs reverse of the function above - it
+# reconstructs dense matrix from a pair of "compressed" matrix, given
+# in the layout used by CUTLASS backend, and accompanying metadata
+# matrix.
+def sparse_semi_structured_to_dense_cutlass(sparse, meta_reordered):
+    if sparse.dim() != 2:
+        raise RuntimeError(
+            f"Expected 2-dimensional sparse tensor, got {sparse.dim()}-dimensional tensor"
+        )
+
+    m, k = sparse.shape
+    device = sparse.device
+
+    if meta_reordered.dim() != 2:
+        raise RuntimeError(
+            f"Expected 2-dimensional meta tensor, got {meta_reordered.dim()}-dimensional tensor"
+        )
+    if meta_reordered.device != device:
+        raise RuntimeError(
+            f"Expected meta matrix to be on {device} device, got matrix on {meta_reordered.device} device"
+        )
+
+    meta_dtype = meta_reordered.dtype
+    if meta_dtype not in (torch.int16, torch.int32):
+        raise RuntimeError(f"Invalid datatype {meta_dtype} of meta matrix")
+    quadbits_per_meta_elem = meta_dtype.itemsize * 8 // 4
+
+    if sparse.dtype != torch.float:
+        ksparse = 4
+    else:
+        ksparse = 2
+
+    meta_nrows, meta_ncols = meta_reordered.shape
+    if meta_nrows != m:
+        raise RuntimeError(
+            f"Number of rows of meta matrix {meta_nrows} must be equal to number of columns of spase matrix {m}"
+        )
+    if meta_ncols * ksparse * quadbits_per_meta_elem != 2 * k:
+        raise RuntimeError(
+            f"Number of columns of sparse matrix {k} different from the {meta_ncols * ksparse * quadbits_per_meta_elem // 2}, "
+            "expected according to the number of columns of meta matrix")
+
+    # Undo meta tensor elements reordering.
+    meta_offsets = _calculate_meta_reordering_scatter_offsets(
+        m, meta_ncols, meta_dtype, device)
+    meta = torch.gather(meta_reordered.view(-1), 0,
+                        meta_offsets).view(m, meta_ncols)
+
+    # Unpack sparse tensor back to original dense tensor, using
+    # information provided by meta tensor.  Note that torch.float
+    # datatype is handled pretty much the same as
+    # torch.half/torch.bfloat16, as metadata for a pair of torch.float
+    # value is encoded as if underlying 8 bytes contain four
+    # torch.half/torch.bfloat16 values, where either first two or last
+    # two are zeros.
+    meta_2 = torch.empty(
+        (m, meta_ncols, 2 * quadbits_per_meta_elem),
+        dtype=meta_dtype,
+        device=device,
+    )
+    if quadbits_per_meta_elem == 4:
+        meta_2[:, :, 0] = meta & 0b11
+        meta_2[:, :, 1] = (meta >> 2) & 0b11
+        meta_2[:, :, 2] = (meta >> 4) & 0b11
+        meta_2[:, :, 3] = (meta >> 6) & 0b11
+        meta_2[:, :, 4] = (meta >> 8) & 0b11
+        meta_2[:, :, 5] = (meta >> 10) & 0b11
+        meta_2[:, :, 6] = (meta >> 12) & 0b11
+        meta_2[:, :, 7] = (meta >> 14) & 0b11
+    elif quadbits_per_meta_elem == 8:
+        meta_2[:, :, 0] = meta & 0b11
+        meta_2[:, :, 1] = (meta >> 2) & 0b11
+        meta_2[:, :, 2] = (meta >> 4) & 0b11
+        meta_2[:, :, 3] = (meta >> 6) & 0b11
+        meta_2[:, :, 4] = (meta >> 8) & 0b11
+        meta_2[:, :, 5] = (meta >> 10) & 0b11
+        meta_2[:, :, 6] = (meta >> 12) & 0b11
+        meta_2[:, :, 7] = (meta >> 14) & 0b11
+        meta_2[:, :, 8] = (meta >> 16) & 0b11
+        meta_2[:, :, 9] = (meta >> 18) & 0b11
+        meta_2[:, :, 10] = (meta >> 20) & 0b11
+        meta_2[:, :, 11] = (meta >> 22) & 0b11
+        meta_2[:, :, 12] = (meta >> 24) & 0b11
+        meta_2[:, :, 13] = (meta >> 26) & 0b11
+        meta_2[:, :, 14] = (meta >> 28) & 0b11
+        meta_2[:, :, 15] = (meta >> 30) & 0b11
+
+    dense_offsets = meta_2.view(-1) + (
+        torch.arange(0, 2 * m * k // ksparse, device=device) * 4).view(
+            -1, 1).repeat(1, 2).view(-1)
+
+    dense = torch.zeros((m * 2 * k, ), dtype=sparse.dtype, device=device)
+    if sparse.dtype != torch.float:
+        #dense.scatter_(0, dense_offsets, sparse.view(-1))
+        dense.scatter_(0, dense_offsets, sparse.reshape(-1))
+    else:
+        dense.view(torch.half).scatter_(0, dense_offsets,
+                                        sparse.view(torch.half).view(-1))
+
+    return dense.view(m, 2 * k)

--- a/auto_gptq/utils/marlin_24_utils.py
+++ b/auto_gptq/utils/marlin_24_utils.py
@@ -226,10 +226,11 @@ def repack_gptq_to_marlin_24(w_gptq, scales, size_k, size_n, num_bits, group_siz
 
 
 def repack_scales_to_marlin_24(s, num_bits, group_size, size_k, size_n):
-    if group_size == -1:
-        group_size = size_k
+    assert group_size == -1 or group_size == 128 or group_size == size_k
 
-    if group_size != size_k:
+    is_channelwise = group_size == -1 or group_size == size_k
+
+    if not is_channelwise:
         s = s.reshape((-1, len(_scale_perm_2_4[num_bits])))[:, _scale_perm_2_4[num_bits]]
     else:
         s = s.reshape((-1, len(_scale_perm_single_2_4[num_bits])))[:, _scale_perm_single_2_4[num_bits]]

--- a/auto_gptq/utils/marlin_24_utils.py
+++ b/auto_gptq/utils/marlin_24_utils.py
@@ -13,12 +13,8 @@ def _get_perms_2_4():
         col = i // 4
         col_o = col // 2
         for block in [0, 1]:
-            for row in [
-                    2 * (i % 4), 2 * (i % 4) + 1, 2 * (i % 4 + 4),
-                    2 * (i % 4 + 4) + 1
-            ]:
-                perm1.append(16 * row + col_o * 256 + 8 * (col % 2) +
-                             4 * block)
+            for row in [2 * (i % 4), 2 * (i % 4) + 1, 2 * (i % 4 + 4), 2 * (i % 4 + 4) + 1]:
+                perm1.append(16 * row + col_o * 256 + 8 * (col % 2) + 4 * block)
         for j in range(4):
             perm.extend([p + 1 * j for p in perm1])
     perm = np.array(perm)
@@ -47,25 +43,19 @@ def unpack_gptq(w_gptq, size_k, size_n, num_bits):
     res = np.zeros((size_k, size_n), dtype=np.uint32)
     w_gptq_cpu = w_gptq.cpu().numpy().astype(np.uint32)
 
-    print("HERE!!!!!! w_gpq = {}".format(w_gptq_cpu))
-
     for i in range(pack_factor):
-        vals = w_gptq_cpu & 0xf
+        vals = w_gptq_cpu & 0xF
         w_gptq_cpu >>= 4
         res[i::8, :] = vals
 
     res = torch.from_numpy(res.astype(np.int32)).to(w_gptq.device)
 
-    print("HERE!!!!!! w_unpacked = {}".format(res[:128, 0]))
-
     return res
 
 
 def reshape_to_group(w, s, size_k, size_n, group_size):
-    assert w.shape[0] == size_k, "w.shape = {}, size_k/n = {}".format(
-        w.shape, (size_k, size_n))
-    assert w.shape[1] == size_n, "w.shape = {}, size_k/n = {}".format(
-        w.shape, (size_k, size_n))
+    assert w.shape[0] == size_k, "w.shape = {}, size_k/n = {}".format(w.shape, (size_k, size_n))
+    assert w.shape[1] == size_n, "w.shape = {}, size_k/n = {}".format(w.shape, (size_k, size_n))
     assert w.dtype == torch.half or w.dtype == torch.int32
 
     if group_size < size_k:
@@ -78,10 +68,8 @@ def reshape_to_group(w, s, size_k, size_n, group_size):
 
 
 def reshape_from_group(w, s, size_k, size_n, group_size):
-    assert w.shape[0] == group_size, "w.shape[0] = {}, group_size = {}".format(
-        w.shape[0], group_size)
-    assert w.dtype == torch.half or w.dtype == torch.int32, "w.dtype = {}".format(
-        w.dtype)
+    assert w.shape[0] == group_size, "w.shape[0] = {}, group_size = {}".format(w.shape[0], group_size)
+    assert w.dtype == torch.half or w.dtype == torch.int32, "w.dtype = {}".format(w.dtype)
 
     if group_size < size_k:
         w = w.reshape((group_size, -1, size_n))
@@ -93,57 +81,6 @@ def reshape_from_group(w, s, size_k, size_n, group_size):
     return w, s
 
 
-def is_24_block(block):
-    return (block != 0).sum() <= 2
-
-
-def fix_24_block(block):
-    # print("Fixing: block = {}".format(block))
-
-    while not is_24_block(block):
-        min_val = 100
-        min_idx = 0
-        for k in range(4):
-            val = abs(block[k])
-            if val != 0 and val < min_val:
-                min_val = val
-                min_idx = k
-        block[min_idx] = 0
-
-    # print("        new_block = {}".format(block))
-    return block
-
-def w_fix_24(w):
-    block_size = 4
-
-    size_k, size_n = w.shape
-
-    w = w.reshape((-1, block_size, size_n))
-    w = w.permute(1, 0, 2)
-    w = w.reshape((block_size, -1))
-
-    mask = w != 0
-
-    non_zeros = torch.sum(mask, 0, keepdim=True)[0]
-
-    n_total = 0
-    n_fixes = 0
-    for i in range(non_zeros.shape[0]):
-        n_total += 1
-        if non_zeros[i] > 2:
-            w[:,i] = fix_24_block(w[:,i].reshape(-1))
-            n_fixes += 1
-
-
-    w = w.reshape((block_size, -1, size_n))
-    w = w.permute(1, 0, 2)
-    w = w.reshape((size_k, size_n)).contiguous()
-
-    print("{} blocks fixed.".format(n_fixes / n_total))
-
-    return w
-
-
 def dequant(w, s, size_k, size_n, num_bits, group_size):
     max_q_val = 2**num_bits - 1
     half_q_val = (max_q_val + 1) // 2
@@ -152,23 +89,9 @@ def dequant(w, s, size_k, size_n, num_bits, group_size):
     w, s = reshape_to_group(w, s, size_k, size_n, group_size)
 
     # Dequantize
-
-    # print("YYY w = {} w.shape = {}".format(w[:64,26807], w.shape))
-    # print("YYY half_q_val = {}".format(half_q_val))
-    # print("YYY w - half_q_val = {}".format((w - half_q_val)[:64,26807]))
-    # print("YYY (w - half_q_val).half() = {}".format(((w - half_q_val).half())[:64,26807]))
-    # print("YYY (w - half_q_val).half() * s = {}".format((((w - half_q_val).half()) * s)[:64,26807]))
-
-    # mask = w != half_q_val
-    # print("MASK mask = {}".format(mask))
-
     w_norm = w - half_q_val
-    # w_norm = w_fix_24(w_norm)
-
     res = w_norm.half() * s
 
-    # print("RES RES res = {} type = {}".format(res, res.type()))
-    # check_24(w - half_q_val)
     # Restore shapes
     res, s = reshape_from_group(res, s, size_k, size_n, group_size)
 
@@ -218,7 +141,7 @@ def check_24(w, num_rows_to_sample=50, _verbose=False):
     for i in sampled_row_idxs:
         for j in range(0, num_cols - BLOCK_SIZE, BLOCK_SIZE):
             total_segments += 1
-            block = w[i, j:j + BLOCK_SIZE]
+            block = w[i, j : j + BLOCK_SIZE]
             num_nonzero = torch.count_nonzero(block)
             if num_nonzero > MAX_NON_ZEROS:
                 print("i = {} j = {} block = {}".format(i, j, block))
@@ -227,36 +150,31 @@ def check_24(w, num_rows_to_sample=50, _verbose=False):
     print(f"{non_24_segments} / {total_segments} do not have 2:4 structure.")
 
 
-def repack_gptq_to_marlin_24(w_gptq,
-                             scales,
-                             size_k,
-                             size_n,
-                             num_bits,
-                             group_size,
-                             marlin_tile=16):
+def repack_gptq_to_marlin_24(w_gptq, scales, size_k, size_n, num_bits, group_size, marlin_tile=16):
     assert num_bits == 4
 
     if group_size == -1:
         group_size = size_k
 
     print(
-        "repack_gptq_to_marlin_24:\n    num_bits = {}\n    group_size = {}\n    w_gptq.shape = {}\n    size_k/n = {}"
-        .format(num_bits, group_size, w_gptq.shape, (size_k, size_n)))
+        "repack_gptq_to_marlin_24:\n    num_bits = {}\n    group_size = {}\n    w_gptq.shape = {}\n    size_k/n = {}".format(
+            num_bits, group_size, w_gptq.shape, (size_k, size_n)
+        )
+    )
 
     # Dequantize
     w_unpacked = unpack_gptq(w_gptq, size_k, size_n, num_bits)
-    print("    w_unpacked: shape = {} type = {}".format(
-        w_unpacked.shape, w_unpacked.type()))
+    print("    w_unpacked: shape = {} type = {}".format(w_unpacked.shape, w_unpacked.type()))
 
     w = dequant(w_unpacked, scales, size_k, size_n, num_bits, group_size)
     print("    w dequant: shape = {} type = {}".format(w.shape, w.type()))
 
+    # DEBUG: Uncomment to verify if all blocks are actually 2:4
     # check_24(w)
 
     # Compress
     w_comp, meta = compress_24(w)
-    print("    w_comp: shape = {} type = {}".format(w_comp.shape,
-                                                    w_comp.type()))
+    print("    w_comp: shape = {} type = {}".format(w_comp.shape, w_comp.type()))
     print("    meta:   shape = {} type = {}".format(meta.shape, meta.type()))
 
     size_k_comp = size_k // 2
@@ -266,11 +184,8 @@ def repack_gptq_to_marlin_24(w_gptq,
     q_w = quant(w_comp, scales, size_k_comp, size_n, num_bits, group_size_comp)
     print("    q_w: shape = {} type = {}".format(q_w.shape, q_w.type()))
 
-    print("HERE: q_w = {}".format(q_w))
-    # time.sleep(300)
     # Reshuffle to marlin_24 format
-    q_w = q_w.reshape((size_k_comp // marlin_tile, marlin_tile,
-                       size_n // marlin_tile, marlin_tile))
+    q_w = q_w.reshape((size_k_comp // marlin_tile, marlin_tile, size_n // marlin_tile, marlin_tile))
     q_w = q_w.permute((0, 2, 1, 3))
     q_w = q_w.reshape((size_k_comp // marlin_tile, size_n * marlin_tile))
 
@@ -294,11 +209,9 @@ def repack_scales_to_marlin_24(s, group_size, size_k, size_n):
         group_size = size_k
 
     if group_size != size_k:
-        # s = s.reshape((1, -1))  # TODO: Remove this line after testing
         s = s.reshape((-1, len(_scale_perm_2_4)))[:, _scale_perm_2_4]
     else:
-        s = s.reshape(
-            (-1, len(_scale_perm_single_2_4)))[:, _scale_perm_single_2_4]
+        s = s.reshape((-1, len(_scale_perm_single_2_4)))[:, _scale_perm_single_2_4]
     s = s.reshape((-1, size_n)).contiguous()
 
     return s

--- a/auto_gptq/utils/marlin_24_utils.py
+++ b/auto_gptq/utils/marlin_24_utils.py
@@ -1,0 +1,304 @@
+import random
+
+import numpy as np
+import torch
+
+from ._semi_structured_conversions import sparse_semi_structured_from_dense_cutlass
+
+
+def _get_perms_2_4():
+    perm = []
+    for i in range(32):
+        perm1 = []
+        col = i // 4
+        col_o = col // 2
+        for block in [0, 1]:
+            for row in [
+                    2 * (i % 4), 2 * (i % 4) + 1, 2 * (i % 4 + 4),
+                    2 * (i % 4 + 4) + 1
+            ]:
+                perm1.append(16 * row + col_o * 256 + 8 * (col % 2) +
+                             4 * block)
+        for j in range(4):
+            perm.extend([p + 1 * j for p in perm1])
+    perm = np.array(perm)
+    interleave = np.array([0, 2, 4, 6, 1, 3, 5, 7])
+    perm = perm.reshape((-1, 8))[:, interleave].ravel()
+    perm = torch.from_numpy(perm)
+    scale_perm = []
+    for i in range(8):
+        scale_perm.extend([i * 8 + j for j in [0, 4, 1, 5, 2, 6, 3, 7]])
+    scale_perm_single = []
+    for i in range(8):
+        scale_perm_single.extend([8 * i + j for j in [0, 1, 2, 3, 4, 5, 6, 7]])
+    return perm, scale_perm, scale_perm_single
+
+
+_perm_2_4, _scale_perm_2_4, _scale_perm_single_2_4 = _get_perms_2_4()
+
+
+def unpack_gptq(w_gptq, size_k, size_n, num_bits):
+    pack_factor = 32 // num_bits
+
+    assert w_gptq.shape[0] * pack_factor == size_k
+    assert w_gptq.shape[1] == size_n
+    assert w_gptq.is_contiguous()
+
+    res = np.zeros((size_k, size_n), dtype=np.uint32)
+    w_gptq_cpu = w_gptq.cpu().numpy().astype(np.uint32)
+
+    print("HERE!!!!!! w_gpq = {}".format(w_gptq_cpu))
+
+    for i in range(pack_factor):
+        vals = w_gptq_cpu & 0xf
+        w_gptq_cpu >>= 4
+        res[i::8, :] = vals
+
+    res = torch.from_numpy(res.astype(np.int32)).to(w_gptq.device)
+
+    print("HERE!!!!!! w_unpacked = {}".format(res[:128, 0]))
+
+    return res
+
+
+def reshape_to_group(w, s, size_k, size_n, group_size):
+    assert w.shape[0] == size_k, "w.shape = {}, size_k/n = {}".format(
+        w.shape, (size_k, size_n))
+    assert w.shape[1] == size_n, "w.shape = {}, size_k/n = {}".format(
+        w.shape, (size_k, size_n))
+    assert w.dtype == torch.half or w.dtype == torch.int32
+
+    if group_size < size_k:
+        w = w.reshape((-1, group_size, size_n))
+        w = w.permute(1, 0, 2)
+        w = w.reshape((group_size, -1))
+    s = s.reshape((1, -1))
+
+    return w, s
+
+
+def reshape_from_group(w, s, size_k, size_n, group_size):
+    assert w.shape[0] == group_size, "w.shape[0] = {}, group_size = {}".format(
+        w.shape[0], group_size)
+    assert w.dtype == torch.half or w.dtype == torch.int32, "w.dtype = {}".format(
+        w.dtype)
+
+    if group_size < size_k:
+        w = w.reshape((group_size, -1, size_n))
+        w = w.permute(1, 0, 2)
+        w = w.reshape((size_k, size_n)).contiguous()
+
+    s = s.reshape((-1, size_n)).contiguous()
+
+    return w, s
+
+
+def is_24_block(block):
+    return (block != 0).sum() <= 2
+
+
+def fix_24_block(block):
+    # print("Fixing: block = {}".format(block))
+
+    while not is_24_block(block):
+        min_val = 100
+        min_idx = 0
+        for k in range(4):
+            val = abs(block[k])
+            if val != 0 and val < min_val:
+                min_val = val
+                min_idx = k
+        block[min_idx] = 0
+
+    # print("        new_block = {}".format(block))
+    return block
+
+def w_fix_24(w):
+    block_size = 4
+
+    size_k, size_n = w.shape
+
+    w = w.reshape((-1, block_size, size_n))
+    w = w.permute(1, 0, 2)
+    w = w.reshape((block_size, -1))
+
+    mask = w != 0
+
+    non_zeros = torch.sum(mask, 0, keepdim=True)[0]
+
+    n_total = 0
+    n_fixes = 0
+    for i in range(non_zeros.shape[0]):
+        n_total += 1
+        if non_zeros[i] > 2:
+            w[:,i] = fix_24_block(w[:,i].reshape(-1))
+            n_fixes += 1
+
+
+    w = w.reshape((block_size, -1, size_n))
+    w = w.permute(1, 0, 2)
+    w = w.reshape((size_k, size_n)).contiguous()
+
+    print("{} blocks fixed.".format(n_fixes / n_total))
+
+    return w
+
+
+def dequant(w, s, size_k, size_n, num_bits, group_size):
+    max_q_val = 2**num_bits - 1
+    half_q_val = (max_q_val + 1) // 2
+
+    # Reshape to [groupsize, -1]
+    w, s = reshape_to_group(w, s, size_k, size_n, group_size)
+
+    # Dequantize
+
+    # print("YYY w = {} w.shape = {}".format(w[:64,26807], w.shape))
+    # print("YYY half_q_val = {}".format(half_q_val))
+    # print("YYY w - half_q_val = {}".format((w - half_q_val)[:64,26807]))
+    # print("YYY (w - half_q_val).half() = {}".format(((w - half_q_val).half())[:64,26807]))
+    # print("YYY (w - half_q_val).half() * s = {}".format((((w - half_q_val).half()) * s)[:64,26807]))
+
+    # mask = w != half_q_val
+    # print("MASK mask = {}".format(mask))
+
+    w_norm = w - half_q_val
+    # w_norm = w_fix_24(w_norm)
+
+    res = w_norm.half() * s
+
+    # print("RES RES res = {} type = {}".format(res, res.type()))
+    # check_24(w - half_q_val)
+    # Restore shapes
+    res, s = reshape_from_group(res, s, size_k, size_n, group_size)
+
+    return res
+
+
+def compress_24(w):
+    w = w.t().contiguous()
+    w_comp, meta = sparse_semi_structured_from_dense_cutlass(w)
+    w_comp = w_comp.t().contiguous()
+    return w_comp, meta
+
+
+def quant(w, s, size_k, size_n, num_bits, group_size):
+    max_q_val = 2**num_bits - 1
+    half_q_val = (max_q_val + 1) // 2
+
+    # Reshape to [groupsize, -1]
+    w, s = reshape_to_group(w, s, size_k, size_n, group_size)
+
+    # Quantize
+    q_w = torch.round(w / s).int()
+    q_w += half_q_val
+    q_w = torch.clamp(q_w, 0, max_q_val)
+
+    # Restore shapes
+    q_w, s = reshape_from_group(q_w, s, size_k, size_n, group_size)
+
+    return q_w
+
+
+def check_24(w, num_rows_to_sample=50, _verbose=False):
+    BLOCK_SIZE = 4
+    MAX_NON_ZEROS = 2
+
+    w = w.t().contiguous()
+
+    print("check_24: w.shape = {}".format(w.shape))
+
+    num_rows, num_cols = w.shape
+    sampled_row_idxs = random.choices(range(num_rows), k=num_rows_to_sample)
+    if _verbose:
+        print(f"Sampled row idxs = {sampled_row_idxs}")
+
+    total_segments = 0
+    non_24_segments = 0
+    for i in sampled_row_idxs:
+        for j in range(0, num_cols - BLOCK_SIZE, BLOCK_SIZE):
+            total_segments += 1
+            block = w[i, j:j + BLOCK_SIZE]
+            num_nonzero = torch.count_nonzero(block)
+            if num_nonzero > MAX_NON_ZEROS:
+                print("i = {} j = {} block = {}".format(i, j, block))
+                non_24_segments += 1
+
+    print(f"{non_24_segments} / {total_segments} do not have 2:4 structure.")
+
+
+def repack_gptq_to_marlin_24(w_gptq,
+                             scales,
+                             size_k,
+                             size_n,
+                             num_bits,
+                             group_size,
+                             marlin_tile=16):
+    assert num_bits == 4
+
+    if group_size == -1:
+        group_size = size_k
+
+    print(
+        "repack_gptq_to_marlin_24:\n    num_bits = {}\n    group_size = {}\n    w_gptq.shape = {}\n    size_k/n = {}"
+        .format(num_bits, group_size, w_gptq.shape, (size_k, size_n)))
+
+    # Dequantize
+    w_unpacked = unpack_gptq(w_gptq, size_k, size_n, num_bits)
+    print("    w_unpacked: shape = {} type = {}".format(
+        w_unpacked.shape, w_unpacked.type()))
+
+    w = dequant(w_unpacked, scales, size_k, size_n, num_bits, group_size)
+    print("    w dequant: shape = {} type = {}".format(w.shape, w.type()))
+
+    # check_24(w)
+
+    # Compress
+    w_comp, meta = compress_24(w)
+    print("    w_comp: shape = {} type = {}".format(w_comp.shape,
+                                                    w_comp.type()))
+    print("    meta:   shape = {} type = {}".format(meta.shape, meta.type()))
+
+    size_k_comp = size_k // 2
+    group_size_comp = group_size // 2
+
+    # Quantize the compressed weight
+    q_w = quant(w_comp, scales, size_k_comp, size_n, num_bits, group_size_comp)
+    print("    q_w: shape = {} type = {}".format(q_w.shape, q_w.type()))
+
+    print("HERE: q_w = {}".format(q_w))
+    # time.sleep(300)
+    # Reshuffle to marlin_24 format
+    q_w = q_w.reshape((size_k_comp // marlin_tile, marlin_tile,
+                       size_n // marlin_tile, marlin_tile))
+    q_w = q_w.permute((0, 2, 1, 3))
+    q_w = q_w.reshape((size_k_comp // marlin_tile, size_n * marlin_tile))
+
+    res = q_w
+    res = res.reshape((-1, _perm_2_4.numel()))[:, _perm_2_4].reshape(res.shape)
+
+    # Pack
+    q = np.zeros((res.shape[0], res.shape[1] // 8), dtype=np.uint32)
+    res = res.cpu().numpy().astype(np.uint32)
+    for i in range(8):
+        q |= res[:, i::8] << 4 * i
+
+    q = torch.from_numpy(q.astype(np.int32)).to(w_gptq.device)
+    print("    q: shape = {} type = {}".format(q.shape, q.type()))
+
+    return q, meta, w
+
+
+def repack_scales_to_marlin_24(s, group_size, size_k, size_n):
+    if group_size == -1:
+        group_size = size_k
+
+    if group_size != size_k:
+        # s = s.reshape((1, -1))  # TODO: Remove this line after testing
+        s = s.reshape((-1, len(_scale_perm_2_4)))[:, _scale_perm_2_4]
+    else:
+        s = s.reshape(
+            (-1, len(_scale_perm_single_2_4)))[:, _scale_perm_single_2_4]
+    s = s.reshape((-1, size_n)).contiguous()
+
+    return s

--- a/auto_gptq/utils/marlin_utils.py
+++ b/auto_gptq/utils/marlin_utils.py
@@ -277,7 +277,7 @@ def convert_to_marlin_24(
                     )
 
             marlin_24_scales = repack_scales_to_marlin_24(
-                module.scales, quantization_config.bits, module.group_size / 2, module.infeatures, module.outfeatures
+                module.scales, quantization_config.bits, module.group_size, module.infeatures, module.outfeatures
             )
 
             new_module.B_24 = marlin_24_weight

--- a/auto_gptq/utils/marlin_utils.py
+++ b/auto_gptq/utils/marlin_utils.py
@@ -12,8 +12,8 @@ from ..nn_modules.qlinear.qlinear_marlin import _get_perms, unpack_qzeros
 from ..quantization import CHECKPOINT_FORMAT, QUANT_METHOD, BaseQuantizeConfig
 from .accelerate_utils import load_checkpoint_in_model
 from .import_utils import MARLIN_AVAILABLE, MARLIN_EXCEPTION
+from .marlin_24_utils import repack_gptq_to_marlin_24, repack_scales_to_marlin_24
 from .modeling_utils import recurse_getattr, recurse_setattr
-
 
 if MARLIN_AVAILABLE:
     import autogptq_marlin_cuda
@@ -28,22 +28,35 @@ def prepare_model_for_marlin_load(
     torch_dtype,
     current_model_save_name,
     device_map,
+    is_24=False,
 ):
     # The model (e.g. model.safetensors) is already serialized in the Marlin format, load it directly.
     if quantize_config.checkpoint_format == CHECKPOINT_FORMAT.MARLIN:
         model_save_name = current_model_save_name
-        logger.info(f"Loading a GPTQ model, detected Marlin serialized format at {model_save_name}.")
-        model = convert_to_marlin(model, quant_linear_class, quantize_config, repack=False)
+        logger.info(
+            f"Loading a GPTQ model, detected Marlin serialized format at {model_save_name}."
+        )
+        model = convert_to_marlin(model,
+                                  quant_linear_class,
+                                  quantize_config,
+                                  repack=False,
+                                  is_24=is_24)
     else:
-        model_save_name, is_cached = quantize_config.get_cache_file_path(quant_method=QUANT_METHOD.GPTQ,
-                                                              checkpoint_format=CHECKPOINT_FORMAT.MARLIN)
+        model_save_name, is_cached = quantize_config.get_cache_file_path(
+            quant_method=QUANT_METHOD.GPTQ,
+            checkpoint_format=CHECKPOINT_FORMAT.MARLIN)
 
         # If GPTQ model has Marlin version cached locally, load from the cached version (no repacking needed).
-        if is_cached:
+        # TODO: Remove this
+        if False and is_cached:
             logger.info(
                 f"Loading a GPTQ model, detected a cached repacked weight for Marlin kernel at {model_save_name}."
             )
-            model = convert_to_marlin(model, quant_linear_class, quantize_config, repack=False)
+            model = convert_to_marlin(model,
+                                      quant_linear_class,
+                                      quantize_config,
+                                      repack=False,
+                                      is_24=is_24)
 
         # Otherwise, convert the model to Marlin format first and cache locally.
         else:
@@ -53,25 +66,32 @@ def prepare_model_for_marlin_load(
             # as for AWQ checkpoints.
             load_checkpoint_in_model(
                 model,
-                dtype=torch_dtype,  # This is very hacky but works due to https://github.com/huggingface/accelerate/blob/bd72a5f1a80d5146554458823f8aeda0a9db5297/src/accelerate/utils/modeling.py#L292
+                dtype=
+                torch_dtype,  # This is very hacky but works due to https://github.com/huggingface/accelerate/blob/bd72a5f1a80d5146554458823f8aeda0a9db5297/src/accelerate/utils/modeling.py#L292
                 checkpoint=current_model_save_name,
                 device_map=device_map,
                 offload_state_dict=True,
                 offload_buffers=True,
             )
             # Convert model to marlin, repacking weights into Marlin format.
-            model = convert_to_marlin(model, quant_linear_class, quantize_config, repack=True)
+            model = convert_to_marlin(model,
+                                      quant_linear_class,
+                                      quantize_config,
+                                      repack=True,
+                                      is_24=is_24)
 
             # Safetensors is unable to save tied weights, so we untie them here. Reference: https://github.com/huggingface/safetensors/issues/202
             tied_params = find_tied_parameters(model)
 
             for weight_group in tied_params:
                 for param_name in weight_group:
-                    if isinstance(recurse_getattr(model, param_name), torch.nn.Parameter):
+                    if isinstance(recurse_getattr(model, param_name),
+                                  torch.nn.Parameter):
                         recurse_setattr(
                             model,
                             param_name,
-                            torch.nn.Parameter(recurse_getattr(model, param_name).clone()),
+                            torch.nn.Parameter(
+                                recurse_getattr(model, param_name).clone()),
                         )
                     else:
                         recurse_setattr(
@@ -121,15 +141,19 @@ def _validate_marlin_compatibility(cfg: BaseQuantizeConfig):
         return "The quantized model uses a group size that is not 128 or -1 (found quantization_config.group_size)"
     if not cfg.sym:
         return "The quantized model uses asymmetric quantization"
-    if cfg.desc_act:
-        return "The quantized model uses act-order (also called desc-act) scheme"
+    # if cfg.desc_act:
+    #     return "The quantized model uses act-order (also called desc-act) scheme"
     if cfg.quant_method == QUANT_METHOD.AWQ:
         return "awq_gemm format is currently not compatible with marlin"
     return None
 
 
 @torch.no_grad()
-def convert_to_marlin(model, model_quantlinear, quantization_config: BaseQuantizeConfig, repack: bool, strict: bool = False):
+def convert_to_marlin_original(model,
+                               model_quantlinear,
+                               quantization_config: BaseQuantizeConfig,
+                               repack: bool,
+                               strict: bool = False):
     """
     Converts GPTQ-packed weights to the Marlin format. This assumes that the model already meets Marlin kernel constraints.
 
@@ -138,17 +162,19 @@ def convert_to_marlin(model, model_quantlinear, quantization_config: BaseQuantiz
             Whether to repack the qweights from `model` into the Marlin's QuantLinear layers.
     """
     if repack:
-        message = "Repacking weights to be compatible with Marlin kernel..."
+        message = "Repacking weights to be compatible with Marlin original (dense) kernel..."
     else:
         # TODO: load directly Marlin QuantLinear.
         message = "Overriding QuantLinear layers to use Marlin's QuantLinear..."
 
-    for name, module in tqdm(model.named_modules(), desc=message, total=len(list(model.named_modules()))):
+    for name, module in tqdm(model.named_modules(),
+                             desc=message,
+                             total=len(list(model.named_modules()))):
         if not isinstance(module, model_quantlinear):
             continue
 
         parent_name = ".".join(name.split(".")[:-1])
-        layer_name = name[len(parent_name) + 1 :]
+        layer_name = name[len(parent_name) + 1:]
 
         # We could use `torch.count_nonzero(module.bias) > 0` here to discard zero bias, but this has issues when
         # loading weights from checkpoints holding zero bias.
@@ -159,15 +185,19 @@ def convert_to_marlin(model, model_quantlinear, quantization_config: BaseQuantiz
                 infeatures=module.infeatures,
                 outfeatures=module.outfeatures,
                 bias=module.bias is not None,
+                is_24=False,
                 trainable=False,
             )
 
         # workspace is never in the state_dict, thus we need to allocate it manually.
-        new_module.workspace = torch.zeros(module.outfeatures // 128 * 16, dtype=torch.int, device=module.device)
+        new_module.workspace = torch.zeros(module.outfeatures // 128 * 16,
+                                           dtype=torch.int,
+                                           device=module.device)
 
         # Dequantize the weight.
         if repack:
-            marlin_repacked_weight = autogptq_marlin_cuda.gptq_repack(module.qweight)
+            marlin_repacked_weight = autogptq_marlin_cuda.gptq_repack(
+                module.qweight)
 
             if strict:
                 dequantized_qzeros = unpack_qzeros(module.qzeros)
@@ -178,7 +208,6 @@ def convert_to_marlin(model, model_quantlinear, quantization_config: BaseQuantiz
                         "Found non-symmetric quantization for the weight {name}."
                     )
 
-
             _, _scale_perm, _scale_perm_single = _get_perms()
 
             s = module.scales.data.clone()
@@ -186,7 +215,8 @@ def convert_to_marlin(model, model_quantlinear, quantization_config: BaseQuantiz
                 s = s.reshape((1, -1))
                 s = s.reshape((-1, len(_scale_perm)))[:, _scale_perm]
             else:
-                s = s.reshape((-1, len(_scale_perm_single)))[:, _scale_perm_single]
+                s = s.reshape(
+                    (-1, len(_scale_perm_single)))[:, _scale_perm_single]
             s = s.reshape((-1, module.outfeatures)).contiguous()
 
             new_module.B = marlin_repacked_weight
@@ -209,3 +239,114 @@ def convert_to_marlin(model, model_quantlinear, quantization_config: BaseQuantiz
     quantization_config.checkpoint_format = CHECKPOINT_FORMAT.MARLIN
 
     return model
+
+
+@torch.no_grad()
+def convert_to_marlin_24(model,
+                         model_quantlinear,
+                         quantization_config: BaseQuantizeConfig,
+                         repack: bool,
+                         strict: bool = False):
+    """
+    Converts GPTQ-packed weights to the Marlin format. This assumes that the model already meets Marlin kernel constraints.
+
+    Arguments:
+        repack (`bool`):
+            Whether to repack the qweights from `model` into the Marlin's QuantLinear layers.
+    """
+    if repack:
+        message = "Repacking weights to be compatible with Marlin_24 (sparse) kernel..."
+    else:
+        # TODO: load directly Marlin QuantLinear.
+        message = "Overriding QuantLinear layers to use Marlin's QuantLinear..."
+
+    for name, module in tqdm(model.named_modules(),
+                             desc=message,
+                             total=len(list(model.named_modules()))):
+        if not isinstance(module, model_quantlinear):
+            continue
+
+        parent_name = ".".join(name.split(".")[:-1])
+        layer_name = name[len(parent_name) + 1:]
+
+        # We could use `torch.count_nonzero(module.bias) > 0` here to discard zero bias, but this has issues when
+        # loading weights from checkpoints holding zero bias.
+        with torch.device("meta"):
+            new_module = MarlinQuantLinear(
+                bits=4,
+                group_size=module.group_size,
+                infeatures=module.infeatures,
+                outfeatures=module.outfeatures,
+                bias=module.bias is not None,
+                is_24=True,
+                trainable=False,
+            )
+
+        # workspace is never in the state_dict, thus we need to allocate it manually.
+        new_module.workspace = torch.zeros(module.outfeatures // 128 * 16,
+                                           dtype=torch.int,
+                                           device=module.device)
+
+        # Dequantize the weight.
+        if repack:
+            marlin_24_weight, marlin_24_meta, marlin_w_ref = repack_gptq_to_marlin_24(
+                module.qweight, module.scales, module.infeatures,
+                module.outfeatures, quantization_config.bits,
+                module.group_size)
+
+            if strict:
+                dequantized_qzeros = unpack_qzeros(module.qzeros)
+
+                if not torch.all(dequantized_qzeros == 8):
+                    raise ValueError(
+                        "Marlin_24 kernel is compatible only with checkpoints using symmetric quantization."
+                        "Found non-symmetric quantization for the weight {name}."
+                    )
+
+            print("HERE !! module.group_size = {}".format(module.group_size))
+            # time.sleep(300)
+            marlin_24_scales = repack_scales_to_marlin_24(
+                module.scales, module.group_size / 2, module.infeatures,
+                module.outfeatures)
+
+            new_module.B_24 = marlin_24_weight
+            new_module.B_meta = marlin_24_meta.resize_(
+                marlin_24_meta.shape[1] // 2, marlin_24_meta.shape[0] * 2)
+            # new_module.B_ref = marlin_w_ref
+            new_module.s = marlin_24_scales
+            new_module.bias = module.bias
+
+            new_module = new_module.to(module.device)
+
+        # Save to parent.
+        parent_module = model.get_submodule(parent_name)
+        setattr(parent_module, layer_name, new_module)
+
+        # Free cuda memory.
+        del module
+        if repack:
+            del marlin_24_weight
+            del marlin_24_meta
+            del marlin_w_ref
+            del marlin_24_scales
+        gc.collect()
+
+    # Set quantization config to be Marlin_24
+    quantization_config.checkpoint_format = CHECKPOINT_FORMAT.MARLIN_24
+
+    return model
+
+
+@torch.no_grad()
+def convert_to_marlin(model,
+                      model_quantlinear,
+                      quantization_config: BaseQuantizeConfig,
+                      repack: bool,
+                      strict: bool = False,
+                      is_24: bool = False):
+    if is_24:
+        return convert_to_marlin_24(model, model_quantlinear,
+                                    quantization_config, repack, strict)
+    else:
+        return convert_to_marlin_original(model, model_quantlinear,
+                                          quantization_config, repack, strict)


### PR DESCRIPTION
This diffs adds the ability to convert a GPTQ model to the 2:4 structured sparse marlin format. This diff is intended to serve as reference for the MLE team to integrate their code (and not be landed on autogptq)

